### PR TITLE
terminate QSetLogging command

### DIFF
--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -341,7 +341,7 @@ int main(int argc, char *argv[])
 			/* enable logging for the session in debug mode */
 			if (debug_level) {
 				debug_info("Setting logging bitmask...");
-				debugserver_command_new("QSetLogging:bitmask=LOG_ALL|LOG_RNB_REMOTE|LOG_RNB_PACKETS", 0, NULL, &command);
+				debugserver_command_new("QSetLogging:bitmask=LOG_ALL|LOG_RNB_REMOTE|LOG_RNB_PACKETS;", 0, NULL, &command);
 				dres = debugserver_client_send_command(debugserver_client, command, &response);
 				debugserver_command_free(command);
 				command = NULL;


### PR DESCRIPTION
The debugserver command to set logging, QSetLogging, needs to be terminated with a ';' for it to be processed.