### PR TITLE
idevicedebug should set internal debug level

### DIFF
--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -230,6 +230,7 @@ int main(int argc, char *argv[])
 		if (!strcmp(argv[i], "-d") || !strcmp(argv[i], "--debug")) {
 			debug_level++;
 			idevice_set_debug_level(debug_level);
+			internal_set_debug_level(debug_level);
 			continue;
 		} else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;


### PR DESCRIPTION
idevicedebug uses debug_info() which requires that it set the internal debug level to display debug info (as well as the idevice debug level).